### PR TITLE
Command parameter

### DIFF
--- a/Demo/DemoApp/DemoApp/MainPage.xaml
+++ b/Demo/DemoApp/DemoApp/MainPage.xaml
@@ -14,11 +14,11 @@
             <Label Text="1.Tap this text to open an url" />
         </StackLayout>
 
-        <StackLayout ui:Gesture.DoubleTapCommand="{Binding OpenVapolia2Command}" IsEnabled="True">
+        <StackLayout ui:Gesture.DoubleTapPointCommand="{Binding OpenVapolia2Command}" IsEnabled="True">
             <Label Text="2.Double tap this text to open an url" />
         </StackLayout>
 
-        <StackLayout ui:Gesture.LongPressCommand="{Binding OpenVapolia2Command}" IsEnabled="True">
+        <StackLayout ui:Gesture.LongPressPointCommand="{Binding OpenVapolia2Command}" IsEnabled="True">
             <Label Text="3.Long press this text to open an url" />
         </StackLayout>
 
@@ -29,7 +29,7 @@
         <StackLayout>
             <Label Text="5.Drag a finger in this space" />
             <BoxView
-                ui:Gesture.PanCommand="{Binding PanCommand}"
+                ui:Gesture.PanPointCommand="{Binding PanPointCommand}"
                 BackgroundColor="Yellow"
                 HeightRequest="200"
                 InputTransparent="False"

--- a/Demo/DemoApp/DemoApp/MainPage.xaml.cs
+++ b/Demo/DemoApp/DemoApp/MainPage.xaml.cs
@@ -34,7 +34,7 @@ namespace DemoApp
                 Children = { new WebView { Source = new UrlWebViewSource { Url = "https://vapolia.fr" }, HorizontalOptions = LayoutOptions.Fill, VerticalOptions = LayoutOptions.Fill} }}});
         });
 
-        public Command<Point> PanCommand => new Command<Point>(point =>
+        public Command<Point> PanPointCommand => new Command<Point>(point =>
         {
             PanX = point.X;
             PanY = point.Y;

--- a/XamarinFormsGesture/Android/PlatformGestureEffect.cs
+++ b/XamarinFormsGesture/Android/PlatformGestureEffect.cs
@@ -26,9 +26,10 @@ namespace Vapolia.Droid.Lib.Effects
     {
         private GestureDetectorCompat gestureRecognizer;
         private readonly InternalGestureDetector tapDetector;
-        private Command<Point> tapCommand2, panCommand, doubleTapCommand, longPressCommand;
-        private ICommand tapCommand, swipeLeftCommand, swipeRightCommand, swipeTopCommand, swipeBottomCommand;
+        private Command<Point> tapPointCommand, panPointCommand, doubleTapPointCommand, longPressPointCommand;
+        private ICommand tapCommand, panCommand, doubleTapCommand, longPressCommand, swipeLeftCommand, swipeRightCommand, swipeTopCommand, swipeBottomCommand;
         private DisplayMetrics displayMetrics;
+        private object commandParameter;
 
         public static void Init()
         {
@@ -41,62 +42,68 @@ namespace Vapolia.Droid.Lib.Effects
                 SwipeThresholdInPoints = 40,
                 TapAction = motionEvent =>
                 {
-                    
-                    var command = tapCommand2;
-                    if (command != null)
+                    if (tapPointCommand != null)
                     {
                         var x = motionEvent.GetX();
                         var y = motionEvent.GetY();
 
                         var point = PxToDp(new Point(x,y));
-                        if (command.CanExecute(point))
-                            command.Execute(point);
+                        if (tapPointCommand.CanExecute(point))
+                            tapPointCommand.Execute(point);
                     }
-                    var handler = tapCommand;
-                    if (handler?.CanExecute(null) == true)
-                        handler.Execute(null);
+
+                    if(tapCommand != null) {
+                        if (tapCommand.CanExecute(commandParameter))
+                            tapCommand.Execute(commandParameter);
+                    }
                 },
                 DoubleTapAction = motionEvent =>
                 {
-                    var command = doubleTapCommand;
-                    if (command != null)
-                    {
+                    if (doubleTapPointCommand != null) {
                         var x = motionEvent.GetX();
                         var y = motionEvent.GetY();
 
                         var point = PxToDp(new Point(x, y));
-                        if (command.CanExecute(point))
-                            command.Execute(point);
+                        if (doubleTapPointCommand.CanExecute(point))
+                            doubleTapPointCommand.Execute(point);
+                    }
+
+                    if (doubleTapCommand != null) {
+                        if (doubleTapCommand.CanExecute(commandParameter))
+                            doubleTapCommand.Execute(commandParameter);
                     }
                 },
                 SwipeLeftAction = motionEvent =>
                 {
-                    var handler = swipeLeftCommand;
-                    if (handler?.CanExecute(null) == true)
-                        handler.Execute(null);
+                    if (swipeLeftCommand != null) {
+                        if (swipeLeftCommand.CanExecute(commandParameter))
+                            swipeLeftCommand.Execute(commandParameter);
+                    }
                 },
                 SwipeRightAction = motionEvent =>
                 {
-                    var handler = swipeRightCommand;
-                    if (handler?.CanExecute(null) == true)
-                        handler.Execute(null);
+                    if (swipeRightCommand != null) {
+                        if (swipeRightCommand.CanExecute(commandParameter))
+                            swipeRightCommand.Execute(commandParameter);
+                    }
                 },
                 SwipeTopAction = motionEvent =>
                 {
-                    var handler = swipeTopCommand;
-                    if (handler?.CanExecute(null) == true)
-                        handler.Execute(null);
+                    if (swipeTopCommand != null) {
+                        if (swipeTopCommand.CanExecute(commandParameter))
+                            swipeTopCommand.Execute(commandParameter);
+                    }
                 },
                 SwipeBottomAction = motionEvent =>
                 {
-                    var handler = swipeBottomCommand;
-                    if (handler?.CanExecute(null) == true)
-                        handler.Execute(null);
+                    if (swipeBottomCommand != null) {
+                        if (swipeBottomCommand.CanExecute(commandParameter))
+                            swipeBottomCommand.Execute(commandParameter);
+                    }
                 },
                 PanAction = (initialDown, currentMove) =>
                 {
-                    var command = panCommand;
-                    if (command != null)
+                    if (panPointCommand != null)
                     {
                         var x0 = initialDown.GetX();
                         var y0 = initialDown.GetY();
@@ -104,21 +111,30 @@ namespace Vapolia.Droid.Lib.Effects
                         var y = currentMove.GetY();
 
                         var point = PxToDp(new Point(x-x0, y-y0));
-                        if (command.CanExecute(point))
-                            command.Execute(point);
+                        if (panPointCommand.CanExecute(point))
+                            panPointCommand.Execute(point);
+                    }
+
+                    if (panCommand != null) {
+                        if (panCommand.CanExecute(commandParameter))
+                            panCommand.Execute(commandParameter);
                     }
                 },
                 LongPressAction = motionEvent =>
                 {
-                    var command = longPressCommand;
-                    if (command != null)
+                    if (longPressPointCommand != null)
                     {
                         var x = motionEvent.GetX();
                         var y = motionEvent.GetY();
 
                         var point = PxToDp(new Point(x, y));
-                        if (command.CanExecute(point))
-                            command.Execute(point);
+                        if (longPressPointCommand.CanExecute(point))
+                            longPressPointCommand.Execute(point);
+                    }
+
+                    if (longPressCommand != null) {
+                        if (longPressCommand.CanExecute(commandParameter))
+                            longPressCommand.Execute(commandParameter);
                     }
                 },
             };
@@ -134,7 +150,7 @@ namespace Vapolia.Droid.Lib.Effects
         protected override void OnElementPropertyChanged(PropertyChangedEventArgs args)
         {
             tapCommand = Gesture.GetTapCommand(Element);
-            tapCommand2 = Gesture.GetTapCommand2(Element);
+            panCommand = Gesture.GetPanCommand(Element);
             doubleTapCommand = Gesture.GetDoubleTapCommand(Element);
             longPressCommand = Gesture.GetLongPressCommand(Element);
 
@@ -142,9 +158,14 @@ namespace Vapolia.Droid.Lib.Effects
             swipeRightCommand = Gesture.GetSwipeRightCommand(Element);
             swipeTopCommand = Gesture.GetSwipeTopCommand(Element);
             swipeBottomCommand = Gesture.GetSwipeBottomCommand(Element);
-            panCommand = Gesture.GetPanCommand(Element);
+
+            tapPointCommand = Gesture.GetTapPointCommand(Element);
+            panPointCommand = Gesture.GetPanPointCommand(Element);
+            doubleTapPointCommand = Gesture.GetDoubleTapPointCommand(Element);
+            longPressPointCommand = Gesture.GetLongPressPointCommand(Element);
 
             tapDetector.SwipeThresholdInPoints = Gesture.GetSwipeThreshold(Element);
+            commandParameter = Gesture.GetCommandParameter(Element);
         }
 
         protected override void OnAttached()

--- a/XamarinFormsGesture/Ios/PlatformGestureEffect.cs
+++ b/XamarinFormsGesture/Ios/PlatformGestureEffect.cs
@@ -25,7 +25,7 @@ namespace Vapolia.Ios.Lib.Effects
         private readonly List<UIGestureRecognizer> recognizers;
 
         private ICommand tapCommand, swipeLeftCommand, swipeRightCommand, swipeTopCommand, swipeBottomCommand;
-        private Command<Point> tapCommand2, panCommand, doubleTapCommand, longPressCommand;
+        private Command<Point> tapPointCommand, panCommand, doubleTapCommand, longPressCommand;
 
         public static void Init()
         {
@@ -38,7 +38,7 @@ namespace Vapolia.Ios.Lib.Effects
             //else
             //    tapDetector.ShouldReceiveTouch = (s, args) => true;
 
-            tapDetector = CreateTapRecognizer(() => Tuple.Create(tapCommand,tapCommand2));
+            tapDetector = CreateTapRecognizer(() => Tuple.Create(tapCommand,tapPointCommand));
             doubleTapDetector = CreateTapRecognizer(() => Tuple.Create((ICommand)null, doubleTapCommand));
             doubleTapDetector.NumberOfTapsRequired = 2;
             longPressDetector = CreateLongPressRecognizer(() => Tuple.Create((ICommand)null, longPressCommand));
@@ -147,15 +147,15 @@ namespace Vapolia.Ios.Lib.Effects
         protected override void OnElementPropertyChanged(PropertyChangedEventArgs args)
         {
             tapCommand = Gesture.GetTapCommand(Element);
-            tapCommand2 = Gesture.GetTapCommand2(Element);
-            doubleTapCommand = Gesture.GetDoubleTapCommand(Element);
-            longPressCommand = Gesture.GetLongPressCommand(Element);
+            tapPointCommand = Gesture.GetTapPointCommand(Element);
+            doubleTapCommand = Gesture.GetDoubleTapPointCommand(Element);
+            longPressCommand = Gesture.GetLongPressPointCommand(Element);
 
             swipeLeftCommand = Gesture.GetSwipeLeftCommand(Element);
             swipeRightCommand = Gesture.GetSwipeRightCommand(Element);
             swipeTopCommand = Gesture.GetSwipeTopCommand(Element);
             swipeBottomCommand = Gesture.GetSwipeBottomCommand(Element);
-            panCommand = Gesture.GetPanCommand(Element);
+            panCommand = Gesture.GetPanPointCommand(Element);
         }
 
         protected override void OnAttached()

--- a/XamarinFormsGesture/Shared/Gesture.cs
+++ b/XamarinFormsGesture/Shared/Gesture.cs
@@ -16,44 +16,64 @@ namespace Vapolia.Lib.Ui
     [Preserve (Conditional=true, AllMembers = true)]
     public static class Gesture
     {
+        /// <summary>
+        /// Android only for now
+        /// </summary>
+        public static readonly BindableProperty LongPressCommandProperty = BindableProperty.CreateAttached("LongPressCommand", typeof(ICommand), typeof(Gesture), null, propertyChanged: CommandChanged);
         public static readonly BindableProperty TapCommandProperty = BindableProperty.CreateAttached("TapCommand", typeof(ICommand), typeof(Gesture), null, propertyChanged: CommandChanged);
-        public static readonly BindableProperty TapCommand2Property = BindableProperty.CreateAttached("TapCommand2", typeof(Command<Point>), typeof(Gesture), null, propertyChanged: CommandChanged);
-        public static readonly BindableProperty DoubleTapCommandProperty = BindableProperty.CreateAttached("DoubleTapCommand", typeof(Command<Point>), typeof(Gesture), null, propertyChanged: CommandChanged);
-        public static readonly BindableProperty PanCommandProperty = BindableProperty.CreateAttached("PanCommand", typeof(Command<Point>), typeof(Gesture), null, propertyChanged: CommandChanged);
+        public static readonly BindableProperty DoubleTapCommandProperty = BindableProperty.CreateAttached("DoubleTapCommand", typeof(ICommand), typeof(Gesture), null, propertyChanged: CommandChanged);
+        public static readonly BindableProperty PanCommandProperty = BindableProperty.CreateAttached("PanCommand", typeof(ICommand), typeof(Gesture), null, propertyChanged: CommandChanged);
+        
         public static readonly BindableProperty SwipeLeftCommandProperty = BindableProperty.CreateAttached("SwipeLeftCommand", typeof(ICommand), typeof(Gesture), null, propertyChanged: CommandChanged);
         public static readonly BindableProperty SwipeRightCommandProperty = BindableProperty.CreateAttached("SwipeRightCommand", typeof(ICommand), typeof(Gesture), null, propertyChanged: CommandChanged);
         public static readonly BindableProperty SwipeTopCommandProperty = BindableProperty.CreateAttached("SwipeTopCommand", typeof(ICommand), typeof(Gesture), null, propertyChanged: CommandChanged);
         public static readonly BindableProperty SwipeBottomCommandProperty = BindableProperty.CreateAttached("SwipeBottomCommand", typeof(ICommand), typeof(Gesture), null, propertyChanged: CommandChanged);
+
+        /// <summary>
+        /// Android only for now
+        /// </summary>
+        public static readonly BindableProperty LongPressPointCommandProperty = BindableProperty.CreateAttached("LongPressPointCommand", typeof(Command<Point>), typeof(Gesture), null, propertyChanged: CommandChanged);
+        public static readonly BindableProperty TapPointCommandProperty = BindableProperty.CreateAttached("TapPointCommand", typeof(Command<Point>), typeof(Gesture), null, propertyChanged: CommandChanged);
+        public static readonly BindableProperty DoubleTapPointCommandProperty = BindableProperty.CreateAttached("DoubleTapPointCommand", typeof(Command<Point>), typeof(Gesture), null, propertyChanged: CommandChanged);
+        public static readonly BindableProperty PanPointCommandProperty = BindableProperty.CreateAttached("PanPointCommand", typeof(Command<Point>), typeof(Gesture), null, propertyChanged: CommandChanged);
+       
         /// <summary>
         /// Android only: min distance to trigger a swipe
         /// </summary>
         public static readonly BindableProperty SwipeThresholdProperty = BindableProperty.CreateAttached("SwipeThreshold", typeof(int), typeof(Gesture), 40, propertyChanged: CommandChanged);
-        /// <summary>
-        /// Android only for now
-        /// </summary>
-        public static readonly BindableProperty LongPressCommandProperty = BindableProperty.CreateAttached("LongPressCommand", typeof(Command<Point>), typeof(Gesture), null, propertyChanged: CommandChanged);
+        public static readonly BindableProperty CommandParameterProperty = BindableProperty.CreateAttached("CommandParameter", typeof(object), typeof(Gesture), null);
 
-
+        public static ICommand GetLongPressCommand(BindableObject view) => (ICommand)view.GetValue(LongPressCommandProperty);
         public static ICommand GetTapCommand(BindableObject view) => (ICommand)view.GetValue(TapCommandProperty);
-        public static Command<Point> GetTapCommand2(BindableObject view) => (Command<Point>)view.GetValue(TapCommand2Property);
-        public static Command<Point> GetDoubleTapCommand(BindableObject view) => (Command<Point>)view.GetValue(DoubleTapCommandProperty);
-        public static void SetTapCommand(BindableObject view, ICommand value) => view.SetValue(TapCommandProperty, value);
-        public static void SetTapCommand2(BindableObject view, Command<Point> value) => view.SetValue(TapCommand2Property, value);
-        public static void SetDoubleTapCommand(BindableObject view, Command<Point> value) => view.SetValue(DoubleTapCommandProperty, value);
-        public static Command<Point> GetPanCommand(BindableObject view) => (Command<Point>)view.GetValue(PanCommandProperty);
-        public static void SetPanCommand(BindableObject view, Command<Point> value) => view.SetValue(PanCommandProperty, value);
+        public static ICommand GetDoubleTapCommand(BindableObject view) => (ICommand)view.GetValue(DoubleTapCommandProperty);
+        public static ICommand GetPanCommand(BindableObject view) => (ICommand)view.GetValue(PanCommandProperty);
         public static ICommand GetSwipeLeftCommand(BindableObject view) => (ICommand)view.GetValue(SwipeLeftCommandProperty);
-        public static void SetSwipeLeftCommand(BindableObject view, ICommand value) => view.SetValue(SwipeLeftCommandProperty, value);
         public static ICommand GetSwipeRightCommand(BindableObject view) => (ICommand)view.GetValue(SwipeRightCommandProperty);
-        public static void SetSwipeRightCommand(BindableObject view, ICommand value) => view.SetValue(SwipeRightCommandProperty, value);
         public static ICommand GetSwipeTopCommand(BindableObject view) => (ICommand)view.GetValue(SwipeTopCommandProperty);
-        public static void SetSwipeTopCommand(BindableObject view, ICommand value) => view.SetValue(SwipeTopCommandProperty, value);
         public static ICommand GetSwipeBottomCommand(BindableObject view) => (ICommand)view.GetValue(SwipeBottomCommandProperty);
+        public static Command<Point> GetLongPressPointCommand(BindableObject view) => (Command<Point>)view.GetValue(LongPressPointCommandProperty);
+        public static Command<Point> GetTapPointCommand(BindableObject view) => (Command<Point>)view.GetValue(TapPointCommandProperty);
+        public static Command<Point> GetDoubleTapPointCommand(BindableObject view) => (Command<Point>)view.GetValue(DoubleTapPointCommandProperty);
+        public static Command<Point> GetPanPointCommand(BindableObject view) => (Command<Point>)view.GetValue(PanPointCommandProperty);
+
+        public static void SetLongPressCommand(BindableObject view, ICommand value) => view.SetValue(LongPressCommandProperty, value);
+        public static void SetTapCommand(BindableObject view, ICommand value) => view.SetValue(TapCommandProperty, value);
+        public static void SetDoubleTapCommand(BindableObject view, ICommand value) => view.SetValue(DoubleTapCommandProperty, value);
+        public static void SetPanCommand(BindableObject view, ICommand value) => view.SetValue(PanCommandProperty, value);
+        public static void SetSwipeLeftCommand(BindableObject view, ICommand value) => view.SetValue(SwipeLeftCommandProperty, value);
+        public static void SetSwipeRightCommand(BindableObject view, ICommand value) => view.SetValue(SwipeRightCommandProperty, value);
+        public static void SetSwipeTopCommand(BindableObject view, ICommand value) => view.SetValue(SwipeTopCommandProperty, value);
         public static void SetSwipeBottomCommand(BindableObject view, ICommand value) => view.SetValue(SwipeBottomCommandProperty, value);
+        public static void SetLongPressPointCommand(BindableObject view, Command<Point> value) => view.SetValue(LongPressPointCommandProperty, value);
+        public static void SetTapPointCommand(BindableObject view, Command<Point> value) => view.SetValue(TapPointCommandProperty, value);
+        public static void SetDoubleTapPointCommand(BindableObject view, Command<Point> value) => view.SetValue(DoubleTapPointCommandProperty, value);
+        public static void SetPanPointCommand(BindableObject view, Command<Point> value) => view.SetValue(PanPointCommandProperty, value);
+
         public static int GetSwipeThreshold(BindableObject view) => (int)view.GetValue(SwipeThresholdProperty);
         public static void SetSwipeThreshold(BindableObject view, int value) => view.SetValue(SwipeThresholdProperty, value);
-        public static Command<Point> GetLongPressCommand(BindableObject view) => (Command<Point>)view.GetValue(LongPressCommandProperty);
-        public static void SetLongPressCommand(BindableObject view, Command<Point> value) => view.SetValue(LongPressCommandProperty, value);
+
+        public static object GetCommandParameter(BindableObject view) => view.GetValue(CommandParameterProperty);
+        public static void SetCommandParameter(BindableObject view, object value) => view.SetValue(CommandParameterProperty, value);
 
         private static GestureEffect GetOrCreateEffect(View view)
         {

--- a/XamarinFormsGesture/Uap/PlatformGestureEffect.cs
+++ b/XamarinFormsGesture/Uap/PlatformGestureEffect.cs
@@ -42,7 +42,7 @@ namespace Vapolia.Uw.Lib.Effects
                 //CrossSlideHorizontally = true
             };
 
-            detector.Dragging += (sender, args) {
+            detector.Dragging += (sender, args) => {
                 TriggerCommand(panCommand, commandParameter);
                 TriggerCommand(panPointCommand, new Point(args.Position.X, args.Position.Y));
             };

--- a/XamarinFormsGesture/Uap/PlatformGestureEffect.cs
+++ b/XamarinFormsGesture/Uap/PlatformGestureEffect.cs
@@ -18,9 +18,10 @@ namespace Vapolia.Uw.Lib.Effects
     public class PlatformGestureEffect : PlatformEffect
     {
         readonly Windows.UI.Input.GestureRecognizer detector;
-        Command<Point> tapCommand2, panCommand, doubleTapCommand, longPressCommand;
-        ICommand tapCommand, swipeLeftCommand, swipeRightCommand, swipeTopCommand, swipeBottomCommand;
+        private Command<Point> tapPointCommand, panPointCommand, doubleTapPointCommand, longPressPointCommand;
+        private ICommand tapCommand, panCommand, doubleTapCommand, longPressCommand, swipeLeftCommand, swipeRightCommand, swipeTopCommand, swipeBottomCommand;
         int swipeThresholdInPoints = 40;
+        private object commandParameter;
 
         public static void Init()
         {
@@ -41,23 +42,30 @@ namespace Vapolia.Uw.Lib.Effects
                 //CrossSlideHorizontally = true
             };
 
-            detector.Dragging += (sender, args) => TriggerCommand(panCommand, new Point(args.Position.X, args.Position.Y));
+            detector.Dragging += (sender, args) {
+                TriggerCommand(panCommand, commandParameter);
+                TriggerCommand(panPointCommand, new Point(args.Position.X, args.Position.Y));
+            }
 
             detector.Tapped += (sender, args) =>
             {
                 if (args.TapCount == 1)
                 {
-                    TriggerCommand(tapCommand, null);
-                    TriggerCommand(tapCommand2, new Point(args.Position.X, args.Position.Y));
+                    TriggerCommand(tapCommand, commandParameter);
+                    TriggerCommand(tapPointCommand, new Point(args.Position.X, args.Position.Y));
                 }
-                else if (args.TapCount == 2)
-                    TriggerCommand(doubleTapCommand, new Point(args.Position.X, args.Position.Y));
+                else if (args.TapCount == 2) {
+                    TriggerCommand(doubleTapCommand, commandParameter);
+                    TriggerCommand(doubleTapPointCommand, new Point(args.Position.X, args.Position.Y));
+                }
             };
 
             detector.Holding += (sender, args) =>
             {
-                if(args.HoldingState == HoldingState.Started)
-                    TriggerCommand(longPressCommand, new Point(args.Position.X, args.Position.Y));
+                if(args.HoldingState == HoldingState.Started) {
+                    TriggerCommand(longPressCommand, commandParameter);
+                    TriggerCommand(longPressPointCommand, new Point(args.Position.X, args.Position.Y));
+                }
             };
 
             //Never called. Don't know why.
@@ -70,12 +78,12 @@ namespace Vapolia.Uw.Lib.Effects
                     if (isHorizontalSwipe)
                     {
                         var isLeftSwipe = args.Delta.Translation.X < 0;
-                        TriggerCommand(isLeftSwipe ? swipeLeftCommand : swipeRightCommand, null);
+                        TriggerCommand(isLeftSwipe ? swipeLeftCommand : swipeRightCommand, commandParameter);
                     }
                     else
                     {
                         var isTopSwipe = args.Delta.Translation.Y < 0;
-                        TriggerCommand(isTopSwipe ? swipeTopCommand : swipeBottomCommand, null);
+                        TriggerCommand(isTopSwipe ? swipeTopCommand : swipeBottomCommand, commandParameter);
                     }
                 }
             };
@@ -88,14 +96,15 @@ namespace Vapolia.Uw.Lib.Effects
 
         private void TriggerCommand(ICommand command, object parameter)
         {
-            if(command?.CanExecute(parameter) == true)
-                command.Execute(parameter);
+            if(command != null)
+                if(command.CanExecute(parameter))
+                    command.Execute(parameter);
         }
 
         protected override void OnElementPropertyChanged(PropertyChangedEventArgs args)
         {
             tapCommand = Gesture.GetTapCommand(Element);
-            tapCommand2 = Gesture.GetTapCommand2(Element);
+            panCommand = Gesture.GetPanCommand(Element);
             doubleTapCommand = Gesture.GetDoubleTapCommand(Element);
             longPressCommand = Gesture.GetLongPressCommand(Element);
 
@@ -103,9 +112,14 @@ namespace Vapolia.Uw.Lib.Effects
             swipeRightCommand = Gesture.GetSwipeRightCommand(Element);
             swipeTopCommand = Gesture.GetSwipeTopCommand(Element);
             swipeBottomCommand = Gesture.GetSwipeBottomCommand(Element);
-            panCommand = Gesture.GetPanCommand(Element);
+
+            tapPointCommand = Gesture.GetTapPointCommand(Element);
+            panPointCommand = Gesture.GetPanPointCommand(Element);
+            doubleTapPointCommand = Gesture.GetDoubleTapPointCommand(Element);
+            longPressPointCommand = Gesture.GetLongPressPointCommand(Element);
 
             swipeThresholdInPoints = Gesture.GetSwipeThreshold(Element);
+            commandParameter = Gesture.GetCommandParameter(Element);
         }
 
         protected override void OnAttached()

--- a/XamarinFormsGesture/Uap/PlatformGestureEffect.cs
+++ b/XamarinFormsGesture/Uap/PlatformGestureEffect.cs
@@ -45,7 +45,7 @@ namespace Vapolia.Uw.Lib.Effects
             detector.Dragging += (sender, args) {
                 TriggerCommand(panCommand, commandParameter);
                 TriggerCommand(panPointCommand, new Point(args.Position.X, args.Position.Y));
-            }
+            };
 
             detector.Tapped += (sender, args) =>
             {


### PR DESCRIPTION
I have implemented Command parameter,

**API Changes**
Every command (except swipe commands) now has two variations. One uses `Point` as command parameter, and another one uses cusom command parameter. 
Example:
    1.  `TapCommand` uses custom `CommandParameter` as parameter
    2.  `TapPointCommand` uses `Point` with tapped location as parameter